### PR TITLE
test: E2E test improvements for WSL environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ stats.html
 stats-*.json
 .wxt
 web-ext.config.ts
+test-results
+playwright-report
 
 # Editor directories and files
 .vscode/*

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -8,12 +8,14 @@ export const test = base.extend<{
 }>({
   // eslint-disable-next-line no-empty-pattern
   context: async ({}, _useContext) => {
-    const pathToExtension = path.join(__dirname, '../.output/chrome-mv3')
+    const pathToExtension = path.resolve('.output/chrome-mv3')
     const context = await chromium.launchPersistentContext('', {
-      headless: false,
+      headless: true,
       args: [
         `--disable-extensions-except=${pathToExtension}`,
         `--load-extension=${pathToExtension}`,
+        '--no-sandbox',
+        '--disable-dev-shm-usage',
       ],
     })
     await _useContext(context)

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "zip:firefox": "wxt zip -b firefox",
     "typecheck": "tsc --noEmit",
     "postinstall": "wxt prepare",
-    "test": "vitest run",
-    "test:e2e": "playwright test",
+    "test": "pnpm test:unit && pnpm test:e2e --reporter=line",
+    "test:unit": "vitest run",
+    "test:e2e": "playwright test --reporter=line",
     "test:e2e:ui": "playwright test --ui",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,8 +8,10 @@ export default defineConfig({
   retries: process.env.CI != null ? 2 : 0,
   workers: process.env.CI != null ? 1 : undefined,
   reporter: 'html',
+  timeout: 30000,
   use: {
     trace: 'on-first-retry',
+    actionTimeout: 10000,
   },
 
   projects: [


### PR DESCRIPTION
## Summary
- ES modules対応でfixturesの__dirnameをpath.resolve()に修正
- WSL環境用にheadlessモードとsandboxオプションを追加  
- Playwrightにタイムアウト設定を追加（30秒、アクション10秒）
- test scriptsを分離してE2Eとunitテストを独立実行可能にした

## Test plan
- [x] Unit tests通過確認
- [x] TypeScript型チェック通過確認
- [x] ESLint通過確認
- [x] E2Eテスト実行確認（WSL環境での依存関係インストール後）

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated test scripts to run both unit and end-to-end tests with improved output formatting.
	- Enhanced Playwright test configuration with global and action timeouts for more reliable test execution.
	- Adjusted end-to-end testing setup for improved compatibility and stability in headless environments.
	- Added new entries to ignore test result and report files in version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->